### PR TITLE
Tweak args; template requires -t, support --

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,15 +16,13 @@ os:
 matrix:
   allow_failures:
     - rust: nightly
+  fast_finish: true
 
 script:
   - cargo test --verbose
   - if rustup component add rustfmt ; then cargo fmt --all -- --check ; fi
   - if rustup component add clippy ; then cargo clippy --all-targets -- -D warnings ; else echo "no clippy"; fi
 
-
-matrix:
-  fast_finish: true
 
 # TODO: set this up to auto-push to crates on a new tag
 # jobs:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-instruments"
-version = "0.1.2"
+version = "0.2.0"
 authors = ["Colin Rofls <colin@cmyr.net>"]
 license = "MIT"
 description = "Generate Xcode Instruments trace files for binary targets."

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ using the `--bin` or `--example` flags.
 _Generate a new trace file_ (by default saved in `/target/instruments`)
 
 ```sh
-$ cargo instruments [template] [--bin foo | --example bar] [--out out_file]
+$ cargo instruments [-t template] [--bin foo | --example bar] [--out out_file]
 ```
 
 _Open the file in Instruments.app_ (or pass `--open` to open automatically)
@@ -44,13 +44,19 @@ Profiler]", which collects CPU core and thread use.
 ### examples
 
 ```sh
-# profile the main binary with the Allocations template
-$ cargo instruments alloc
+# View all args and options
+$ cargo instruments --help
 ```
 
 ```sh
-# profile examples my_example.rs
-$ cargo instruments --example my_example
+# profile the main binary with the Allocations template
+$ cargo instruments -t alloc
+```
+
+```sh
+# profile examples/my_example.rs, with the default template,
+# for 10 seconds, and open the trace when finished
+$ cargo instruments --example my_example --limit 10000 --open
 ```
 
 ## Resources

--- a/src/opt.rs
+++ b/src/opt.rs
@@ -15,11 +15,12 @@ pub(crate) enum Cli {
 }
 
 #[derive(Debug, StructOpt)]
+#[structopt(raw(setting = "structopt::clap::AppSettings::TrailingVarArg"))]
 pub(crate) struct Opts {
     /// Specify the instruments template to run
     ///
     /// To see available templates, pass --list.
-    #[structopt(default_value = "time", value_name = "TEMPLATE")]
+    #[structopt(short = "t", long, default_value = "time", value_name = "TEMPLATE")]
     pub(crate) template: String,
     /// Example binary to run
     #[structopt(long, group = "target", value_name = "NAME")]
@@ -48,9 +49,9 @@ pub(crate) struct Opts {
     #[structopt(long)]
     pub(crate) open: bool,
 
-    /// Arguments passed to the target binary. If you're having trouble,
-    /// try wrapping args in double and single quotes, like --args '"-h --fun plz"'.
-    #[structopt(short = "a", long = "args", value_name = "ARGS")]
+    /// Arguments passed to the target binary. To pass flags, precede child args
+    /// with --, e.g. `cargo instruments -- -t test1.txt --slow-mode`.
+    #[structopt(value_name = "ARGS")]
     pub(crate) target_args: Vec<String>,
 }
 
@@ -131,11 +132,19 @@ mod tests {
 
     #[test]
     fn var_args() {
-        // this isn't ideal, but works for now
-        let opts =
-            Opts::from_iter(&["instruments", "alloc", "--limit", "808", "--args", "hi -h --bin"]);
+        let opts = Opts::from_iter(&[
+            "instruments",
+            "-t",
+            "alloc",
+            "--limit",
+            "808",
+            "--",
+            "hi",
+            "-h",
+            "--bin",
+        ]);
         assert_eq!(opts.template, "alloc");
         assert_eq!(opts.limit, Some(808));
-        assert_eq!(opts.target_args, vec!["hi -h --bin"]);
+        assert_eq!(opts.target_args, vec!["hi", "-h", "--bin"]);
     }
 }


### PR DESCRIPTION
Passing a custom template now requires an explicit -t flag,
but passing args to the child no longer requires --args.