### PR TITLE
Forward `cargo`'s cargo feature `vendored_openssl`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,6 @@ cargo = "0.42.0"
 failure = "0.1.5"
 structopt = { version = "0.3", default-features = false }
 termcolor = "1.0"
+
+[features]
+vendored-openssl = ["cargo/vendored-openssl"]


### PR DESCRIPTION
Hi and thank you for making this tool!

This PR allows a user without a shared OpenSSL library to choose to install with a statically linked copy of OpenSSL, by using:

```
cargo install cargo-instruments --feature vendored_openssl
```