### PR TITLE
Show stdout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -145,6 +145,7 @@ dependencies = [
  "anyhow",
  "cargo",
  "chrono",
+ "ctrlc",
  "structopt",
  "termcolor",
 ]
@@ -296,6 +297,16 @@ dependencies = [
  "commoncrypto",
  "hex 0.3.2",
  "openssl",
+ "winapi",
+]
+
+[[package]]
+name = "ctrlc"
+version = "3.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b57a92e9749e10f25a171adcebfafe72991d45e7ec2dcb853e8f83d9dafaeb08"
+dependencies = [
+ "nix",
  "winapi",
 ]
 
@@ -685,6 +696,18 @@ checksum = "5a33c1b55807fbed163481b5ba66db4b2fa6cde694a5027be10fb724206c5897"
 dependencies = [
  "socket2",
  "winapi",
+]
+
+[[package]]
+name = "nix"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83450fe6a6142ddd95fb064b746083fc4ef1705fe81f64a64e1d4b39f54a1055"
+dependencies = [
+ "bitflags",
+ "cc",
+ "cfg-if 0.1.10",
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ edition = "2018"
 
 [dependencies]
 chrono = "0.4.6"
+ctrlc = "3.1.7"
 cargo = "0.47.0"
 anyhow = "1.0"
 structopt = { version = "0.3", default-features = false }

--- a/src/app.rs
+++ b/src/app.rs
@@ -40,6 +40,8 @@ pub(crate) fn run(args: Opts) -> Result<()> {
     let relpath = exec_path.strip_prefix(&workspace_root).unwrap_or_else(|_| exec_path.as_path());
     workspace.config().shell().status("Profiling", relpath.to_string_lossy())?;
 
+    ctrlc::set_handler(move || {})?;
+
     let trace_path = match instruments::run(&args, exec_path, &workspace_root) {
         Ok(path) => path,
         Err(e) => {


### PR DESCRIPTION
This replaces the deprecated `instruments` command with the `xcrun xctrace` command. Terminal output is now displayed by specifying the `--target-stdin` and `--target-stdout` options.

Additionally pressing CTRL-C will now gracefully exit and output the trace path.

fixes #4 