### PR TITLE
Cargo bump, Instruments selection, and refactor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,15 +2,15 @@
 # It is not intended for manual editing.
 [[package]]
 name = "adler"
-version = "0.2.3"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee2a4ec343196209d6594e19543ae87a39f96d5534d7174822a3ad825dd6ed7e"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.15"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7404febffaa47dac81aa44dba71523c9d069b1bdc50a77db41195149e17f68e5"
+checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
 dependencies = [
  "memchr",
 ]
@@ -26,9 +26,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.35"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c0df63cb2955042487fad3aefd2c6e3ae7389ac5dc1beb28921de0b69f779d4"
+checksum = "28b2cd92db5cbd74e8e5028f7e27dd7aa3090e89e4f2a197cc7c8dfb69c7063b"
 
 [[package]]
 name = "atty"
@@ -64,9 +64,9 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "0.2.14"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "473fc6b38233f9af7baa94fb5852dca389e3d95b8e21c8e3719301462c5d9faf"
+checksum = "90682c8d613ad3373e66de8c6411e0ae2ab2571e879d2efbf73558cc66f21279"
 dependencies = [
  "memchr",
 ]
@@ -79,9 +79,9 @@ checksum = "81a18687293a1546b67c246452202bbbf143d239cb43494cc163da14979082da"
 
 [[package]]
 name = "cargo"
-version = "0.47.0"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d435f32d32f191cdf788ef94403d7566dc5fcdadbcf7cd191cc0d2f9079d0a4"
+checksum = "668794d3757557250a8b7bf7d0920ca60910d9635e76d008caed037ec25c39b3"
 dependencies = [
  "anyhow",
  "atty",
@@ -90,7 +90,7 @@ dependencies = [
  "clap",
  "core-foundation",
  "crates-io",
- "crossbeam-utils 0.7.2",
+ "crossbeam-utils",
  "crypto-hash",
  "curl",
  "curl-sys",
@@ -101,9 +101,9 @@ dependencies = [
  "git2",
  "git2-curl",
  "glob",
- "hex 0.4.2",
+ "hex 0.4.3",
  "home",
- "humantime 2.0.1",
+ "humantime",
  "ignore",
  "im-rc",
  "jobserver",
@@ -116,12 +116,11 @@ dependencies = [
  "miow",
  "num_cpus",
  "opener",
- "openssl",
  "percent-encoding",
  "rustc-workspace-hack",
  "rustfix",
  "same-file",
- "semver",
+ "semver 0.10.0",
  "serde",
  "serde_ignored",
  "serde_json",
@@ -140,11 +139,13 @@ dependencies = [
 
 [[package]]
 name = "cargo-instruments"
-version = "0.3.4"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "cargo",
  "chrono",
+ "dialoguer",
+ "semver 0.9.0",
  "structopt",
  "termcolor",
 ]
@@ -160,18 +161,12 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.66"
+version = "1.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c0496836a84f8d0495758516b8621a622beb77c0fed418570e50764093ced48"
+checksum = "e3c69b077ad434294d3ce9f1f6143a2a4b89a8a2d54ef813d85003a4fd1137fd"
 dependencies = [
  "jobserver",
 ]
-
-[[package]]
-name = "cfg-if"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
 name = "cfg-if"
@@ -226,6 +221,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3993e6445baa160675931ec041a5e03ca84b9c6e32a056150d3aa2bdda0a1f45"
+dependencies = [
+ "encode_unicode",
+ "lazy_static",
+ "libc",
+ "regex",
+ "terminal_size",
+ "unicode-width",
+ "winapi",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -243,15 +253,14 @@ checksum = "ea221b5284a47e40033bf9b66f35f984ec0ea2931eb03505246cd27a963f981b"
 
 [[package]]
 name = "crates-io"
-version = "0.31.1"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09f977948a46e9edf93eb3dc2d7a8dd4ce3105d36de63300befed37cdf051d4a"
+checksum = "217138863f33507d7a8edef10fc673c4911679ef7aeb9ff53ee7bb82dc7bf590"
 dependencies = [
  "anyhow",
  "curl",
  "percent-encoding",
  "serde",
- "serde_derive",
  "serde_json",
  "url",
 ]
@@ -262,28 +271,17 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81156fece84ab6a9f2afdb109ce3ae577e42b1228441eded99bd77f627953b1a"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.7.2"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
+checksum = "4feb231f0d4d6af81aed15928e58ecf5816aa62a2393e2c82f46973e92a9a278"
 dependencies = [
  "autocfg",
- "cfg-if 0.1.10",
- "lazy_static",
-]
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02d96d1e189ef58269ebe5b97953da3274d83a93af647c2ddd6f9dab28cedb8d"
-dependencies = [
- "autocfg",
- "cfg-if 1.0.0",
+ "cfg-if",
  "lazy_static",
 ]
 
@@ -301,9 +299,9 @@ dependencies = [
 
 [[package]]
 name = "curl"
-version = "0.4.34"
+version = "0.4.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e268162af1a5fe89917ae25ba3b0a77c8da752bdc58e7dbb4f15b91fbd33756e"
+checksum = "d0bac9f84ca0977c4d9b8db998689de55b9e976656a6bc87fada2ca710d504c7"
 dependencies = [
  "curl-sys",
  "libc",
@@ -316,9 +314,9 @@ dependencies = [
 
 [[package]]
 name = "curl-sys"
-version = "0.4.38+curl-7.73.0"
+version = "0.4.42+curl-7.76.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "498ecfb4f59997fd40023d62a9f1e506e768b2baeb59a1d311eb9751cdcd7e3f"
+checksum = "4636d8d6109c842707018a104051436bffb8991ea20b2d1293db70b6e0ee4c7c"
 dependencies = [
  "cc",
  "libc",
@@ -331,13 +329,31 @@ dependencies = [
 ]
 
 [[package]]
-name = "env_logger"
-version = "0.7.1"
+name = "dialoguer"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
+checksum = "c9dd058f8b65922819fabb4a41e7d1964e56344042c26efbccd465202c23fa0c"
+dependencies = [
+ "console",
+ "lazy_static",
+ "tempfile",
+ "zeroize",
+]
+
+[[package]]
+name = "encode_unicode"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
+
+[[package]]
+name = "env_logger"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17392a012ea30ef05a610aa97dfb49496e71c9f676b27879922ea5bdf60d9d3f"
 dependencies = [
  "atty",
- "humantime 1.3.0",
+ "humantime",
  "log",
  "regex",
  "termcolor",
@@ -345,11 +361,11 @@ dependencies = [
 
 [[package]]
 name = "filetime"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c122a393ea57648015bf06fbd3d372378992e86b9ff5a7a497b076a28c79efe"
+checksum = "1d34cfa13a63ae058bfa601fe9e313bbdb3746427c1459185464ce0fcf62e1e8"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "redox_syscall",
  "winapi",
@@ -357,11 +373,11 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7411863d55df97a419aa64cb4d2f167103ea9d767e2c54a1868b7ac3f6b47129"
+checksum = "cd3aec53de10fe96d7d8c565eb17f2c687bb5518a2ec453b5b1252964526abe0"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "crc32fast",
  "libc",
  "libz-sys",
@@ -391,9 +407,9 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ece68d15c92e84fa4f19d3780f1294e5ca82a78a6d515f1efaabcc144688be00"
+checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
 dependencies = [
  "matches",
  "percent-encoding",
@@ -411,20 +427,20 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.1.15"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc587bc0ec293155d5bfa6b9891ec18a1e330c234f896ea47fbada4cadbe47e6"
+checksum = "c9495705279e7140bf035dde1f6e750c162df8b625267cd52cc44e0b156732c8"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if",
  "libc",
- "wasi 0.9.0+wasi-snapshot-preview1",
+ "wasi",
 ]
 
 [[package]]
 name = "git2"
-version = "0.13.12"
+version = "0.13.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca6f1a0238d7f8f8fd5ee642f4ebac4dbc03e03d1f78fbe7a3ede35dcf7e2224"
+checksum = "b483c6c2145421099df1b4efd50e0f6205479a072199460eff852fa15e5603c7"
 dependencies = [
  "bitflags",
  "libc",
@@ -468,18 +484,18 @@ dependencies = [
 
 [[package]]
 name = "heck"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
+checksum = "87cbf45460356b7deeb5e3415b5563308c0a9b057c85e12b06ad551f98d0a6ac"
 dependencies = [
  "unicode-segmentation",
 ]
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aca5565f760fb5b220e499d72710ed156fdb74e631659e99377d9ebfbd13ae8"
+checksum = "322f4de77956e22ed0e5032c359a0f1273f1f7f0d79bfa3b8ffbc730d7fbcc5c"
 dependencies = [
  "libc",
 ]
@@ -492,9 +508,9 @@ checksum = "805026a5d0141ffc30abb3be3173848ad46a1b1664fe632428479619a3644d77"
 
 [[package]]
 name = "hex"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "644f9158b2f133fd50f5fb3242878846d9eb792e445c893805ff0e3824006e35"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "home"
@@ -507,24 +523,15 @@ dependencies = [
 
 [[package]]
 name = "humantime"
-version = "1.3.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
-dependencies = [
- "quick-error",
-]
-
-[[package]]
-name = "humantime"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c1ad908cc71012b7bea4d0c53ba96a8cba9962f048fa68d143376143d863b7a"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "idna"
-version = "0.2.0"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02e2673c30ee86b5b96a9cb52ad15718aa1f966f5ab9ad54a8b95d5ca33120a9"
+checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
 dependencies = [
  "matches",
  "unicode-bidi",
@@ -537,7 +544,7 @@ version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b287fb45c60bb826a0dc68ff08742b9d88a2fea13d6e0c286b3172065aaf878c"
 dependencies = [
- "crossbeam-utils 0.8.1",
+ "crossbeam-utils",
  "globset",
  "lazy_static",
  "log",
@@ -556,7 +563,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ca8957e71f04a205cb162508f9326aea04676c8dfd0711220190d6b83664f3f"
 dependencies = [
  "bitmaps",
- "rand_core",
+ "rand_core 0.5.1",
  "rand_xoshiro",
  "sized-chunks",
  "typenum",
@@ -565,15 +572,15 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6"
+checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
 
 [[package]]
 name = "jobserver"
-version = "0.1.21"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c71313ebb9439f74b00d9d2dcec36440beaf57a6aa0623068441dd7cd81a7f2"
+checksum = "972f5ae5d1cb9c6ae417789196c803205313edde988685da5e3aae0827b9e7fd"
 dependencies = [
  "libc",
 ]
@@ -592,15 +599,15 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.81"
+version = "0.2.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1482821306169ec4d07f6aca392a4681f66c75c9918aa49641a2595db64053cb"
+checksum = "18794a8ad5b29321f790b55d93dfba91e125cb1a9edbd4f8e3150acc771c1a5e"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.12.14+1.1.0"
+version = "0.12.19+1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f25af58e6495f7caf2919d08f212de550cfa3ed2f5e744988938ea292b9f549"
+checksum = "f322155d574c8b9ebe991a04f6908bb49e68a79463338d24a43d6274cb6443e6"
 dependencies = [
  "cc",
  "libc",
@@ -612,9 +619,9 @@ dependencies = [
 
 [[package]]
 name = "libnghttp2-sys"
-version = "0.1.5+1.42.0"
+version = "0.1.6+1.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9657455ff47889b70ffd37c3e118e8cdd23fd1f9f3293a285f141070621c4c79"
+checksum = "0af55541a8827e138d59ec9e5877fb6095ece63fb6f4da45e7491b4fbd262855"
 dependencies = [
  "cc",
  "libc",
@@ -622,9 +629,9 @@ dependencies = [
 
 [[package]]
 name = "libssh2-sys"
-version = "0.2.20"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df40b13fe7ea1be9b9dffa365a51273816c345fc1811478b57ed7d964fbfc4ce"
+checksum = "e0186af0d8f171ae6b9c4c90ec51898bad5d08a2d5e470903a50d9ad8959cbee"
 dependencies = [
  "cc",
  "libc",
@@ -636,9 +643,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "602113192b08db8f38796c4e85c39e960c145965140e918018bcde1952429655"
+checksum = "de5435b8549c16d423ed0c03dbaafe57cf6c3344744f1242520d59c9d8ecec66"
 dependencies = [
  "cc",
  "libc",
@@ -648,11 +655,11 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.11"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
+checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if",
 ]
 
 [[package]]
@@ -663,15 +670,15 @@ checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 
 [[package]]
 name = "memchr"
-version = "2.3.4"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
+checksum = "b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f2d26ec3309788e423cfbf68ad1800f061638098d76a83681af979dc4eda19d"
+checksum = "a92518e98c078586bc6c934028adcca4c92a53d6a958196de835170a01d84e4b"
 dependencies = [
  "adler",
  "autocfg",
@@ -679,11 +686,10 @@ dependencies = [
 
 [[package]]
 name = "miow"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a33c1b55807fbed163481b5ba66db4b2fa6cde694a5027be10fb724206c5897"
+checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
 dependencies = [
- "socket2",
  "winapi",
 ]
 
@@ -717,6 +723,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "once_cell"
+version = "1.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af8b08b04175473088b46763e51ee54da5f9a164bc162f615b91bc179dbf15a3"
+
+[[package]]
 name = "opener"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -727,15 +739,15 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.30"
+version = "0.10.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d575eff3665419f9b83678ff2815858ad9d11567e082f5ac1814baba4e2bcb4"
+checksum = "6d7830286ad6a3973c0f1d9b73738f69c76b739301d0229c4b96501695cbe4c8"
 dependencies = [
  "bitflags",
- "cfg-if 0.1.10",
+ "cfg-if",
  "foreign-types",
- "lazy_static",
  "libc",
+ "once_cell",
  "openssl-sys",
 ]
 
@@ -746,24 +758,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 
 [[package]]
-name = "openssl-src"
-version = "111.12.0+1.1.1h"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "858a4132194f8570a7ee9eb8629e85b23cbc4565f2d4a162e87556e5956abf61"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "openssl-sys"
-version = "0.9.58"
+version = "0.9.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a842db4709b604f0fe5d1170ae3565899be2ad3d9cbc72dedc789ac0511f78de"
+checksum = "fa52160d45fa2e7608d504b7c3a3355afed615e6d8b627a74458634ba21b69bd"
 dependencies = [
  "autocfg",
  "cc",
  "libc",
- "openssl-src",
  "pkg-config",
  "vcpkg",
 ]
@@ -812,49 +814,42 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.24"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e0704ee1a7e00d7bb417d0770ea303c1bccbabf0ef1667dae92b5967f5f8a71"
+checksum = "a152013215dca273577e18d2bf00fa862b89b24169fb78c4c95aeb07992c9cec"
 dependencies = [
  "unicode-xid",
 ]
 
 [[package]]
-name = "quick-error"
-version = "1.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
-
-[[package]]
 name = "quote"
-version = "1.0.7"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa563d17ecb180e500da1cfd2b028310ac758de548efdd203e18f283af693f37"
+checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "rand"
-version = "0.7.3"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
+checksum = "0ef9e7e66b4468674bfcb0c81af8b7fa0bb154fa9f28eb840da5c447baeb8d7e"
 dependencies = [
- "getrandom",
  "libc",
  "rand_chacha",
- "rand_core",
+ "rand_core 0.6.2",
  "rand_hc",
 ]
 
 [[package]]
 name = "rand_chacha"
-version = "0.2.2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
+checksum = "e12735cf05c9e10bf21534da50a147b924d555dc7a547c42e6bb2d5b6017ae0d"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.2",
 ]
 
 [[package]]
@@ -862,17 +857,23 @@ name = "rand_core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
+
+[[package]]
+name = "rand_core"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34cf66eb183df1c5876e2dcf6b13d57340741e8dc255b48e40a26de954d06ae7"
 dependencies = [
  "getrandom",
 ]
 
 [[package]]
 name = "rand_hc"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
+checksum = "3190ef7066a446f2e7f42e239d161e905420ccab01eb967c9eb27d21b2322a73"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.2",
 ]
 
 [[package]]
@@ -881,32 +882,34 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9fcdd2e881d02f1d9390ae47ad8e5696a9e4be7b547a1da2afbc61973217004"
 dependencies = [
- "rand_core",
+ "rand_core 0.5.1",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.1.57"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
+checksum = "742739e41cd49414de871ea5e549afb7e2a3ac77b589bcbebe8c82fab37147fc"
+dependencies = [
+ "bitflags",
+]
 
 [[package]]
 name = "regex"
-version = "1.4.2"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38cf2c13ed4745de91a5eb834e11c00bcc3709e773173b2ce4c56c9fbde04b9c"
+checksum = "ce5f1ceb7f74abbce32601642fcf8e8508a8a8991e0621c7d750295b9095702b"
 dependencies = [
  "aho-corasick",
  "memchr",
  "regex-syntax",
- "thread_local",
 ]
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.21"
+version = "0.6.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b181ba2dcf07aaccad5448e8ead58db5b742cf85dfe035e2227f137a539a189"
+checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 
 [[package]]
 name = "remove_dir_all"
@@ -962,6 +965,15 @@ dependencies = [
 
 [[package]]
 name = "semver"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
+dependencies = [
+ "semver-parser",
+]
+
+[[package]]
+name = "semver"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "394cec28fa623e00903caf7ba4fa6fb9a0e260280bb8cdbbba029611108a0190"
@@ -978,18 +990,18 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.118"
+version = "1.0.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06c64263859d87aa2eb554587e2d23183398d617427327cf2b3d0ed8c69e4800"
+checksum = "558dc50e1a5a5fa7112ca2ce4effcb321b0300c0d4ccf0776a9f60cd89031171"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.118"
+version = "1.0.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c84d3526699cd55261af4b941e4e725444df67aa4f9e6a3564f18030d12672df"
+checksum = "b093b7a2bb58203b5da3056c05b4ec1fed827dcfdb37347a8841695263b3d06d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1007,9 +1019,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.60"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1500e84d27fe482ed1dc791a56eddc2f230046a040fa908c08bda1d9fb615779"
+checksum = "799e97dc9fdae36a5c8b8f2cae9ce2ee9fdce2058c57a93e6099d919fd982f79"
 dependencies = [
  "itoa",
  "ryu",
@@ -1024,9 +1036,9 @@ checksum = "45bb67a18fa91266cc7807181f62f9178a6873bfad7dc788c42e6430db40184f"
 
 [[package]]
 name = "sized-chunks"
-version = "0.6.2"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ec31ceca5644fa6d444cc77548b88b67f46db6f7c71683b0f9336e671830d2f"
+checksum = "16d69225bde7a69b235da73377861095455d298f2b970996eec25ddbb42b3d1e"
 dependencies = [
  "bitmaps",
  "typenum",
@@ -1034,13 +1046,11 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.3.17"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c29947abdee2a218277abeca306f25789c938e500ea5a9d4b12a5a504466902"
+checksum = "9e3dfc207c526015c632472a77be09cf1b6e46866581aecae5cc38fb4235dea2"
 dependencies = [
- "cfg-if 1.0.0",
  "libc",
- "redox_syscall",
  "winapi",
 ]
 
@@ -1085,9 +1095,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.54"
+version = "1.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2af957a63d6bd42255c359c93d9bfdb97076bd3b820897ce55ffbfbf107f44"
+checksum = "a1e8cdbefb79a9a5a65e0db8b47b723ee907b7c7f8496c76a1770b5c310bab82"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1096,22 +1106,21 @@ dependencies = [
 
 [[package]]
 name = "tar"
-version = "0.4.30"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "489997b7557e9a43e192c527face4feacc78bfbe6eed67fd55c4c9e381cba290"
+checksum = "c0bcfbd6a598361fda270d82469fff3d65089dc33e175c9a131f7b4cd395f228"
 dependencies = [
  "filetime",
  "libc",
- "redox_syscall",
 ]
 
 [[package]]
 name = "tempfile"
-version = "3.1.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
+checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if",
  "libc",
  "rand",
  "redox_syscall",
@@ -1129,6 +1138,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "terminal_size"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86ca8ced750734db02076f44132d802af0b33b09942331f4459dde8636fd2406"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "textwrap"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1139,29 +1158,28 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.0.1"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"
+checksum = "8018d24e04c95ac8790716a5987d0fec4f8b27249ffa0f7d33f1369bdfb88cbd"
 dependencies = [
- "lazy_static",
+ "once_cell",
 ]
 
 [[package]]
 name = "time"
-version = "0.1.44"
+version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
+checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
 dependencies = [
  "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
  "winapi",
 ]
 
 [[package]]
 name = "tinyvec"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccf8dbc19eb42fba10e8feaaec282fb50e2c14b2726d6301dbfeed0f73306a6f"
+checksum = "5b5220f05bb7de7f3f53c7c065e1199b3172696fe2db9f9c4d8ad9b4ee74c342"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -1174,33 +1192,33 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "toml"
-version = "0.5.7"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75cf45bb0bef80604d001caaec0d09da99611b3c0fd39d3080468875cdb65645"
+checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "typenum"
-version = "1.12.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33"
+checksum = "879f6906492a7cd215bfa4cf595b600146ccfac0c79bcbd1f3000162af5e8b06"
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
+checksum = "eeb8be209bb1c96b7c177c7420d26e04eccacb0eeae6b980e35fcb74678107e0"
 dependencies = [
  "matches",
 ]
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a13e63ab62dbe32aeee58d1c5408d35c36c392bba5d9d3142287219721afe606"
+checksum = "07fbfce1c8a97d547e8b5334978438d9d6ec8c20e38f56d4a4374d181493eaef"
 dependencies = [
  "tinyvec",
 ]
@@ -1219,15 +1237,15 @@ checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
 
 [[package]]
 name = "unicode-xid"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
+checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
 name = "url"
-version = "2.2.0"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5909f2b0817350449ed73e8bcd81c8c3c8d9a7a5d8acba4b27db277f1868976e"
+checksum = "9ccd964113622c8e9322cfac19eb1004a07e636c545f325da085d5cdde6f1f8b"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -1243,9 +1261,9 @@ checksum = "8772a4ccbb4e89959023bc5b7cb8623a795caa7092d99f3aa9501b9484d4557d"
 
 [[package]]
 name = "vcpkg"
-version = "0.2.10"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6454029bf181f092ad1b853286f23e2c507d8e8194d01d92da4a55c274a5508c"
+checksum = "cbdbff6266a24120518560b5dc983096efb98462e51d0d68169895b237be3e5d"
 
 [[package]]
 name = "vec_map"
@@ -1255,9 +1273,9 @@ checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
+checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
 
 [[package]]
 name = "vte"
@@ -1270,9 +1288,9 @@ dependencies = [
 
 [[package]]
 name = "walkdir"
-version = "2.3.1"
+version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "777182bc735b6424e1a57516d35ed72cb8019d85c8c9bf536dccb3445c1a2f7d"
+checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
 dependencies = [
  "same-file",
  "winapi",
@@ -1281,15 +1299,9 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.9.0+wasi-snapshot-preview1"
+version = "0.10.2+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
-
-[[package]]
-name = "wasi"
-version = "0.10.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
+checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "winapi"
@@ -1321,3 +1333,9 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "zeroize"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4756f7db3f7b5574938c3eb1c117038b8e07f95ee6718c0efad4ac21508f1efd"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,22 +1,21 @@
 [package]
 name = "cargo-instruments"
-version = "0.3.4"
+version = "0.4.0"
 authors = ["Colin Rofls <colin@cmyr.net>"]
 license = "MIT"
-description = "Generate Xcode Instruments trace files for binary targets."
+description = "Profile binary targets on macOS using Xcode Instruments."
 repository = "https://github.com/cmyr/cargo-instruments"
 documentation = "https://github.com/cmyr/cargo-instruments"
 categories = ["development-tools::cargo-plugins", "development-tools::profiling"]
-keywords = ["profiling", "xcode", "instruments", "macos"]
+keywords = ["profiling", "xcode", "cargo-subcommand", "instruments", "trace", "xctrace", "macos"]
 readme = "README.md"
 edition = "2018"
 
 [dependencies]
-chrono = "0.4.6"
-cargo = "0.47.0"
 anyhow = "1.0"
-structopt = { version = "0.3", default-features = false }
+cargo = "0.52"
+chrono = "0.4.6"
+dialoguer = "^0.8.0"
+structopt = { version = "^0.3", default-features = false }
+semver = "^0.9"
 termcolor = "1.0"
-
-[features]
-vendored-openssl = ["cargo/vendored-openssl"]

--- a/src/instruments.rs
+++ b/src/instruments.rs
@@ -1,133 +1,388 @@
 //! interfacing with the `instruments` command line tool
 
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
 
 use anyhow::{anyhow, Result};
+use cargo::core::Workspace;
+use semver::Version;
 
-use crate::opt::Opts;
+use crate::opt::AppConfig;
 
-/// Check that `instruments` is in $PATH.
-pub(crate) fn check_existence() -> Result<()> {
-    let path = ["/", "usr", "bin", "instruments"].iter().collect::<PathBuf>();
-    if path.exists() {
-        Ok(())
-    } else {
+/// Holds available templates.
+pub struct TemplateCatalog {
+    standard_templates: Vec<String>,
+    custom_templates: Vec<String>,
+}
+
+/// Represents the Xcode Instrument version detected.
+pub enum XcodeInstruments {
+    XcTrace,
+    InstrumentsBinary,
+}
+
+impl XcodeInstruments {
+    /// Detects which version of Xcode Instruments is installed and if it can be launched.
+    pub(crate) fn detect() -> Result<XcodeInstruments> {
+        let cur_version = get_macos_version()?;
+        let macos_xctrace_version = Version::parse("10.15.0").unwrap();
+
+        if cur_version >= macos_xctrace_version {
+            // This is the check used by Homebrew,see
+            // https://github.com/Homebrew/install/blob/a1d820fc8950312c35073700d0ea88a531bc5950/install.sh#L216
+            let clt_git_filepath = Path::new("/Library/Developer/CommandLineTools/usr/bin/git");
+            if clt_git_filepath.exists() {
+                return Ok(XcodeInstruments::XcTrace);
+            }
+        } else {
+            let instruments_app_filepath = Path::new("/usr/bin/instruments");
+            if instruments_app_filepath.exists() {
+                return Ok(XcodeInstruments::InstrumentsBinary);
+            }
+        }
         Err(anyhow!(
-            "/usr/bin/instruments does not exist. \
-             Please install the Xcode Command Line Tools."
+            "Xcode Instruments is not installed. Please install the Xcode Command Line Tools."
         ))
+    }
+
+    /// Return a catalog of available Instruments Templates.
+    ///
+    /// The custom templates only appears if you have custom templates.
+    pub(crate) fn available_templates(&self) -> Result<TemplateCatalog> {
+        match self {
+            XcodeInstruments::XcTrace => parse_xctrace_template_list(),
+            XcodeInstruments::InstrumentsBinary => parse_instruments_template_list(),
+        }
+    }
+
+    /// Prepare the Xcode Instruments profiling command
+    ///
+    /// If the `xctrace` tool is used, the prepared command looks like
+    ///
+    /// ```sh
+    /// xcrun xctrace record --template MyTemplate \
+    ///                      --time-limit 5000ms \
+    ///                      --output path/to/tracefile \
+    ///                      --launch \
+    ///                      --
+    /// ```
+    ///
+    /// If the older `instruments` tool is used, the prepared command looks
+    /// like
+    ///
+    /// ```sh
+    /// instruments -t MyTemplate \
+    ///             -D /path/to/tracefile \
+    ///             -l 5000ms
+    /// ```
+    fn profiling_command(
+        &self,
+        template_name: &str,
+        trace_filepath: &Path,
+        time_limit: Option<usize>,
+    ) -> Command {
+        match self {
+            XcodeInstruments::XcTrace => {
+                let mut command = Command::new("xcrun");
+                command.args(&["xctrace", "record"]);
+
+                command.args(&["--template", &template_name]);
+
+                if let Some(limit_millis) = time_limit {
+                    let limit_millis_str = format!("{}ms", limit_millis);
+                    command.args(&["--time-limit", &limit_millis_str]);
+                }
+
+                command.args(&["--output", &trace_filepath.to_str().unwrap()]);
+
+                command.args(&["--launch", "--"]);
+
+                command
+            }
+            XcodeInstruments::InstrumentsBinary => {
+                let mut command = Command::new("instruments");
+                command.args(&["-t", &template_name]);
+
+                command.arg("-D").arg(&trace_filepath);
+
+                if let Some(limit) = time_limit {
+                    command.args(&["-l", &limit.to_string()]);
+                }
+
+                command
+            }
+        }
     }
 }
 
-/// Return a string listing available templates.
-pub(crate) fn list() -> Result<String> {
+/// Return the macOS version.
+///
+/// This function parses the output of `sw_vers -productVersion` (a string like '11.2.3`)
+/// and returns the corresponding semver struct `Version{major: 11, minor: 2, patch: 3}`.
+fn get_macos_version() -> Result<Version> {
+    let Output { status, stdout, .. } =
+        Command::new("sw_vers").args(&["-productVersion"]).output()?;
+
+    if !status.success() {
+        return Err(anyhow!("macOS version cannot be determined"));
+    }
+
+    let version_string = std::str::from_utf8(&stdout)?;
+    Version::parse(&version_string).map_err(|error| {
+        anyhow!("cannot parse version: `{}`, because of {}", version_string, error)
+    })
+}
+
+/// Parse xctrace template listing.
+///
+/// Xctrace prints the list on either stderr (older versions) or stdout (recent).
+/// In either case, the expected output is:
+///
+/// ```
+/// == Standard Templates ==
+/// Activity Monitor
+/// Allocations
+/// Animation Hitches
+/// App Launch
+/// Core Data
+/// Counters
+/// Energy Log
+/// File Activity
+/// Game Performance
+/// Leaks
+/// Logging
+/// Metal System Trace
+/// Network
+/// SceneKit
+/// SwiftUI
+/// System Trace
+/// Time Profiler
+/// Zombies
+///
+/// == Custom Templates ==
+/// MyTemplate
+/// ```
+fn parse_xctrace_template_list() -> Result<TemplateCatalog> {
+    let Output { status, stdout, stderr } =
+        Command::new("xcrun").args(&["xctrace", "list", "templates"]).output()?;
+
+    if !status.success() {
+        return Err(anyhow!(
+            "Could not list templates. Please check your Xcode Instruments installation."
+        ));
+    }
+
+    // Some older versions of xctrace print results on stderr,
+    // newer version print results on stdout.
+    let output = if stdout.is_empty() { stderr } else { stdout };
+
+    let templates_str = std::str::from_utf8(&output)?;
+    let mut templates_iter = templates_str.lines();
+
+    let standard_templates = templates_iter
+        .by_ref()
+        .skip(1)
+        .map(|line| line.trim())
+        .take_while(|line| !line.starts_with('=') && !line.is_empty())
+        .map(|line| line.into())
+        .collect::<Vec<_>>();
+
+    if standard_templates.is_empty() {
+        return Err(anyhow!(
+            "No available templates. Please check your Xcode Instruments installation."
+        ));
+    }
+
+    let custom_templates = templates_iter
+        .map(|line| line.trim())
+        .skip_while(|line| line.starts_with('=') || line.is_empty())
+        .map(|line| line.into())
+        .collect::<Vec<_>>();
+
+    Ok(TemplateCatalog { standard_templates, custom_templates })
+}
+
+/// Parse /usr/bin/instruments template list.
+///
+/// The expected output on stdout is:
+///
+/// ```
+/// Known Templates:
+/// "Activity Monitor"
+/// "Allocations"
+/// "Animation Hitches"
+/// "App Launch"
+/// "Blank"
+/// "Core Data"
+/// "Counters"
+/// "Energy Log"
+/// "File Activity"
+/// "Game Performance"
+/// "Leaks"
+/// "Logging"
+/// "Metal System Trace"
+/// "Network"
+/// "SceneKit"
+/// "SwiftUI"
+/// "System Trace"
+/// "Time Profiler"
+/// "Zombies"
+/// "~/Library/Application Support/Instruments/Templates/MyTemplate.tracetemplate"
+/// ```
+fn parse_instruments_template_list() -> Result<TemplateCatalog> {
     let Output { status, stdout, .. } =
         Command::new("instruments").args(&["-s", "templates"]).output()?;
 
     if !status.success() {
-        return Err(anyhow!("'instruments -s templates' command errored"));
+        return Err(anyhow!(
+            "Could not list templates. Please check your Xcode Instruments installation."
+        ));
     }
 
-    let templates = String::from_utf8(stdout)?;
-    let mut output: String = "Instruments provides the following built-in templates.\n\
-                              Aliases are indicated in parentheses.\n"
-        .into();
+    let templates_str = std::str::from_utf8(&stdout)?;
 
-    let mut templates = templates
+    let standard_templates = templates_str
         .lines()
         .skip(1)
-        .map(|line| (line, abbrev_name(line.trim().trim_matches('"'))))
+        .map(|line| line.trim().trim_matches('"'))
+        .take_while(|line| !line.starts_with("~/Library/"))
+        .map(|line| line.into())
         .collect::<Vec<_>>();
 
-    if templates.is_empty() {
-        return Err(anyhow!("no templates returned from 'instruments -s templates'"));
+    if standard_templates.is_empty() {
+        return Err(anyhow!(
+            "No available templates. Please check your Xcode Instruments installation."
+        ));
     }
 
-    let max_width = templates.iter().map(|(l, _)| l.len()).max().unwrap();
+    let custom_templates = templates_str
+        .lines()
+        .map(|line| line.trim().trim_matches('"'))
+        .skip_while(|line| !line.starts_with("~/Library/"))
+        .take_while(|line| !line.is_empty())
+        .map(|line| Path::new(line).file_stem().unwrap().to_string_lossy())
+        .map(|line| line.into())
+        .collect::<Vec<_>>();
 
-    templates.sort_by_key(|&(_, abbrv)| abbrv.is_none());
+    Ok(TemplateCatalog { standard_templates, custom_templates })
+}
 
-    for (name, abbrv) in templates {
+/// Render the template catalog content as a string.
+///
+/// The returned string is similar to
+///
+/// ```text
+/// Xcode Instruments templates:
+///
+/// built-in            abbrev
+/// --------------------------
+/// Activity Monitor
+/// Allocations         (alloc)
+/// Animation Hitches
+/// App Launch
+/// Core Data
+/// Counters
+/// Energy Log
+/// File Activity       (io)
+/// Game Performance
+/// Leaks
+/// Logging
+/// Metal System Trace
+/// Network
+/// SceneKit
+/// SwiftUI
+/// System Trace        (sys)
+/// Time Profiler       (time)
+/// Zombies
+///
+/// custom
+/// --------------------------
+/// MyTemplate
+/// ```
+pub fn render_template_catalog(catalog: &TemplateCatalog) -> String {
+    let mut output: String = "Xcode Instruments templates:\n".into();
+
+    let max_width = catalog
+        .standard_templates
+        .iter()
+        .chain(catalog.custom_templates.iter())
+        .map(|name| name.len())
+        .max()
+        .unwrap();
+
+    // column headers
+    output.push_str(&format!("\n{:width$}abbrev", "built-in", width = max_width + 2));
+    output.push_str(&format!("\n{:-<width$}", "", width = max_width + 8));
+
+    for name in &catalog.standard_templates {
         output.push('\n');
-        output.push_str(name);
-        if let Some(abbrv) = abbrv {
-            let some_spaces = "                                              ";
-            let lpad = (max_width - name.len()).min(some_spaces.len());
-            output.push_str(&some_spaces[..lpad]);
-            output.push_str(&format!("({})", abbrv));
+        if let Some(abbrv) = abbrev_name(name.trim_matches('"')) {
+            output.push_str(&format!(
+                "{:width$}({abbrev})",
+                name,
+                width = max_width + 2,
+                abbrev = abbrv
+            ));
+        } else {
+            output.push_str(name);
         }
     }
 
-    Ok(output)
-}
+    output.push('\n');
 
-pub(crate) fn run(args: &Opts, exec_path: PathBuf, workspace_root: &PathBuf) -> Result<PathBuf> {
-    let outfile = get_out_file(args, &exec_path, &workspace_root)?;
-    let template = resolve_template(&args);
+    // column headers
+    output.push_str(&format!("\n{:width$}", "custom", width = max_width + 2));
+    output.push_str(&format!("\n{:-<width$}", "", width = max_width + 8));
 
-    let mut command = Command::new("instruments");
-    command.args(&["-t", &template]).arg("-D").arg(&outfile);
-
-    if let Some(limit) = args.limit {
-        command.args(&["-l", &limit.to_string()]);
+    for name in &catalog.custom_templates {
+        output.push('\n');
+        output.push_str(name);
     }
 
-    command.arg(&exec_path);
+    output.push('\n');
 
-    if !args.target_args.is_empty() {
-        command.args(args.target_args.as_slice());
-    }
-
-    let output = command.output()?;
-
-    if !output.status.success() {
-        let stderr =
-            String::from_utf8(output.stderr).unwrap_or_else(|_| "failed to capture stderr".into());
-        Err(anyhow!("instruments errored: {}", stderr))
-    } else {
-        Ok(outfile)
-    }
+    output
 }
 
-fn get_out_file(args: &Opts, exec_path: &PathBuf, workspace_root: &PathBuf) -> Result<PathBuf> {
-    if let Some(path) = args.output.clone() {
-        return Ok(path);
+/// Compute the tracefile output path, creating the directory structure
+/// in `target/instruments` if needed.
+fn prepare_trace_filepath(
+    target_filepath: &Path,
+    template_name: &str,
+    app_config: &AppConfig,
+    workspace_root: &Path,
+) -> Result<PathBuf> {
+    if let Some(ref path) = app_config.trace_filepath {
+        return Ok(path.to_path_buf());
     }
 
-    let exec_name = exec_path
-        .file_stem()
-        .and_then(|s| s.to_str())
-        .ok_or_else(|| anyhow!("invalid exec path {:?}", exec_path))?;
+    let trace_dir = workspace_root.join("target").join("instruments");
 
-    let filename = format!("{}_{}", exec_name, now_timestamp());
-    let mut path = get_target_dir(workspace_root)?;
-    path.push(filename);
-    path.set_extension("trace");
-    Ok(path)
-}
-
-fn get_target_dir(workspace_root: &PathBuf) -> Result<PathBuf> {
-    let mut target_dir = workspace_root.clone();
-    target_dir.push("target");
-    target_dir.push("instruments");
-    if !target_dir.exists() {
-        fs::create_dir_all(&target_dir)
-            .map_err(|e| anyhow!("failed to create {:?}: {}", &target_dir, e))?;
+    if !trace_dir.exists() {
+        fs::create_dir_all(&trace_dir)
+            .map_err(|e| anyhow!("failed to create {:?}: {}", &trace_dir, e))?;
     }
-    Ok(target_dir)
+
+    let trace_filename = {
+        let target_shortname = target_filepath
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .ok_or_else(|| anyhow!("invalid target path {:?}", target_filepath))?;
+        let template_name_escaped = template_name.replace(' ', "-");
+        let now = chrono::Local::now();
+
+        format!("{}_{}_{}.trace", target_shortname, template_name_escaped, now.format("%FT%T"))
+    };
+
+    let trace_filepath = trace_dir.join(trace_filename);
+
+    Ok(trace_filepath)
 }
 
-fn now_timestamp() -> impl std::fmt::Display {
-    use chrono::prelude::*;
-    let now = Local::now();
-    let fmt = "%FT%T";
-    now.format(&fmt)
-}
-
-fn resolve_template(args: &Opts) -> &str {
-    match args.template.as_str() {
+/// Return the complete template name, replacing abbreviation if provided.
+fn resolve_template_name(template_name: &str) -> &str {
+    match template_name {
         "time" => "Time Profiler",
         "alloc" => "Allocations",
         "io" => "File Activity",
@@ -136,12 +391,66 @@ fn resolve_template(args: &Opts) -> &str {
     }
 }
 
-fn abbrev_name(template: &str) -> Option<&'static str> {
-    match template {
+/// Return the template name abbreviation if available.
+fn abbrev_name(template_name: &str) -> Option<&str> {
+    match template_name {
         "Time Profiler" => Some("time"),
         "Allocations" => Some("alloc"),
         "File Activity" => Some("io"),
         "System Trace" => Some("sys"),
         _ => None,
     }
+}
+
+/// Profile the target binary at `binary_filepath`, write results at
+/// `trace_filepath` and returns its path.
+pub(crate) fn profile_target(
+    target_filepath: &Path,
+    xctrace_tool: &XcodeInstruments,
+    app_config: &AppConfig,
+    workspace: &Workspace,
+) -> Result<PathBuf> {
+    // 1. Get the template name from config
+    // This borrows a ref to the String in Option<String>. The value can be
+    // unwrapped because in this version the template was checked earlier to
+    // be a `Some(x)`.
+    let template_name = resolve_template_name(app_config.template_name.as_deref().unwrap());
+
+    // 2. Compute the trace filepath and create its parent directory
+    let workspace_root = workspace.root().to_path_buf();
+    let trace_filepath = prepare_trace_filepath(
+        target_filepath,
+        &template_name,
+        app_config,
+        workspace_root.as_path(),
+    )?;
+
+    // 3. Print current activity `Profiling target/debug/tries`
+    {
+        let target_shortpath = target_filepath
+            .strip_prefix(workspace_root)
+            .unwrap_or(target_filepath)
+            .to_string_lossy();
+        let status_detail = format!("{} with template '{}'", target_shortpath, template_name);
+        workspace.config().shell().status("Profiling", status_detail)?;
+    }
+
+    let mut command =
+        xctrace_tool.profiling_command(&template_name, &trace_filepath, app_config.time_limit);
+
+    command.arg(&target_filepath);
+
+    if !app_config.target_args.is_empty() {
+        command.args(app_config.target_args.as_slice());
+    }
+
+    let output = command.output()?;
+
+    if !output.status.success() {
+        let stderr =
+            String::from_utf8(output.stderr).unwrap_or_else(|_| "failed to capture stderr".into());
+        return Err(anyhow!("instruments errored: {}", stderr));
+    }
+
+    Ok(trace_filepath)
 }


### PR DESCRIPTION
Hello Colin,

I love your project, it really opened my eyes on what's possible with Instruments, even on Rust!

I wanted to provide a few improvements, but then I ended up refactoring the code much more than I had expected!

I don't think looking at the diff can provide a good overview of what has changed because I have moved too many pieces around. I think it's much easier to clone and read the code to see the logic, the names, etc.

In a nutshell
- variable names have changed from `opts`, `args` to `cargo_options`, `app_config`, etc, because I was having a hard time following
- more comments
- changed a bit the options
- Xcode Instruments selection mechanism (`xctrace` or `instruments`)
- gather templates into a catalog `struct`
- no default template: provide interactive selection if no template is provided

I have not changed much to the cargo manipulations, I just updated to 0.52's `UnitOutput` and leveraged `workspace.root()` to get the path.

I really hope you will like it, discuss and merge, but, truly, I'd understand such a refactoring looks inopportune and I apologize if that's the case.

Best regards