### PR TITLE
Fix invalid version for os with 0 as patch number

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -140,7 +140,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-instruments"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "cargo",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-instruments"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Colin Rofls <colin@cmyr.net>"]
 license = "MIT"
 description = "Profile binary targets on macOS using Xcode Instruments."

--- a/src/instruments.rs
+++ b/src/instruments.rs
@@ -146,8 +146,8 @@ fn semver_from_utf8(version: &[u8]) -> Result<Version> {
 
     let version_string = std::str::from_utf8(version)?;
     match version_string.split('.').count() {
-        1 => to_semver(&format!("{}.0.0", version_string.trim_end_matches('\n'))),
-        2 => to_semver(&format!("{}.0", version_string.trim_end_matches('\n'))),
+        1 => to_semver(&format!("{}.0.0", version_string.trim())),
+        2 => to_semver(&format!("{}.0", version_string.trim())),
         3 => to_semver(version_string),
         _ => Err(anyhow!("invalid version: {}", version_string)),
     }


### PR DESCRIPTION
On macOS `11.1.0` the version number returned by `sw_vers -productVersion` does not have a patch number, i.e. it returns `11.1`. So  `semver::Version::parse()` fails. This PR appends the version number in case it's missing a patch or minor number so that the parsing succeeds. 