### PR TITLE
fix: support rust 1.54

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -405,9 +405,9 @@ dependencies = [
 
 [[package]]
 name = "git2"
-version = "0.13.19"
+version = "0.13.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17929de7239dea9f68aa14f94b2ab4974e7b24c1314275ffcc12a7758172fa18"
+checksum = "659cd14835e75b64d9dba5b660463506763cf0aa6cb640aeeb0e98d841093490"
 dependencies = [
  "bitflags",
  "libc",
@@ -572,9 +572,9 @@ checksum = "18794a8ad5b29321f790b55d93dfba91e125cb1a9edbd4f8e3150acc771c1a5e"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.12.20+1.1.0"
+version = "0.12.22+1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e2f09917e00b9ad194ae72072bb5ada2cca16d8171a43e91ddba2afbb02664b"
+checksum = "89c53ac117c44f7042ad8d8f5681378dfbc6010e49ec2c0d1f11dfedc7a4a1c3"
 dependencies = [
  "cc",
  "libc",


### PR DESCRIPTION
This upgrades `git2` to fix an incompatibility with `rust` 1.54

<details>
  <summary>Stacktrace</summary>

```
error[E0495]: cannot infer an appropriate lifetime due to conflicting requirements
  --> /Users/brew/Library/Caches/Homebrew/cargo_cache/registry/src/github.com-1ecc6299db9ec823/git2-0.13.19/src/attr.rs:74:15
   |
74 |         match (self, other) {
   |               ^^^^^^^^^^^^^
   |
note: first, the lifetime cannot outlive the anonymous lifetime defined on the method body at 73:26...
  --> /Users/brew/Library/Caches/Homebrew/cargo_cache/registry/src/github.com-1ecc6299db9ec823/git2-0.13.19/src/attr.rs:73:26
   |
73 |     fn eq(&self, other: &AttrValue<'_>) -> bool {
   |                          ^^^^^^^^^^^^^
note: ...so that the types are compatible
  --> /Users/brew/Library/Caches/Homebrew/cargo_cache/registry/src/github.com-1ecc6299db9ec823/git2-0.13.19/src/attr.rs:74:15
   |
74 |         match (self, other) {
   |               ^^^^^^^^^^^^^
   = note: expected `(&AttrValue<'_>, &AttrValue<'_>)`
              found `(&AttrValue<'_>, &AttrValue<'_>)`
note: but, the lifetime must be valid for the lifetime `'_` as defined on the impl at 72:30...
  --> /Users/brew/Library/Caches/Homebrew/cargo_cache/registry/src/github.com-1ecc6299db9ec823/git2-0.13.19/src/attr.rs:72:30
   |
72 | impl PartialEq for AttrValue<'_> {
   |                              ^^
note: ...so that the types are compatible
  --> /Users/brew/Library/Caches/Homebrew/cargo_cache/registry/src/github.com-1ecc6299db9ec823/git2-0.13.19/src/attr.rs:79:16
   |
79 |             | (Self::Bytes(bytes), AttrValue::String(string)) => string.as_bytes() == *bytes,
   |                ^^^^^^^^^^^^^^^^^^
   = note: expected `AttrValue<'_>`
              found `AttrValue<'_>`

error: aborting due to previous error

For more information about this error, try `rustc --explain E0495`.
error: failed to compile `cargo-instruments v0.4.1 (/private/tmp/cargo-instruments-20210801-36371-8u06ls/cargo-instruments-0.4.1)`, intermediate artifacts can be found at `/private/tmp/cargo-instruments-20210801-36371-8u06ls/cargo-instruments-0.4.1/target`

Caused by:
  could not compile `git2`

To learn more, run the command again with --verbose.
```
</details>

For more info, see
* `rust` change: https://github.com/rust-lang/rust/issues/85574
* `git2` fix: https://github.com/rust-lang/git2-rs/pull/712