### PR TITLE
Fix for BigSur's code signing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -405,9 +405,9 @@ dependencies = [
 
 [[package]]
 name = "git2"
-version = "0.13.19"
+version = "0.13.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17929de7239dea9f68aa14f94b2ab4974e7b24c1314275ffcc12a7758172fa18"
+checksum = "659cd14835e75b64d9dba5b660463506763cf0aa6cb640aeeb0e98d841093490"
 dependencies = [
  "bitflags",
  "libc",
@@ -572,9 +572,9 @@ checksum = "18794a8ad5b29321f790b55d93dfba91e125cb1a9edbd4f8e3150acc771c1a5e"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.12.20+1.1.0"
+version = "0.12.22+1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e2f09917e00b9ad194ae72072bb5ada2cca16d8171a43e91ddba2afbb02664b"
+checksum = "89c53ac117c44f7042ad8d8f5681378dfbc6010e49ec2c0d1f11dfedc7a4a1c3"
 dependencies = [
  "cc",
  "libc",

--- a/src/app.rs
+++ b/src/app.rs
@@ -50,6 +50,22 @@ pub(crate) fn run(app_config: AppConfig) -> Result<()> {
         }
     };
 
+    // 3.2: Ad-hoc code sign the target so instruments can run
+    let codesign_output =
+        Command::new("codesign").args(&["-s", "-", target_filepath.to_str().unwrap()]).output()?;
+    if !codesign_output.status.success() {
+        workspace.config().shell().status_with_color(
+            "Code Sign Failed - Stdout",
+            String::from_utf8(codesign_output.stdout)?,
+            Color::Black,
+        )?;
+        workspace.config().shell().status_with_color(
+            "Code Sign Failed - Stderr",
+            String::from_utf8(codesign_output.stderr)?,
+            Color::Red,
+        )?;
+    }
+
     // 4. Profile the built target, will display menu if no template was selected
     let trace_filepath =
         match instruments::profile_target(&target_filepath, &xctrace_tool, &app_config, &workspace)


### PR DESCRIPTION
In troubleshooting my setup for this tool on a M1 Mac I discovered [this blog post](https://eclecticlight.co/2020/08/22/apple-silicon-macs-will-require-signed-code/) identifying a fix to MacOS's new code signing requirements.

This pull request also includes @ndustrialio 's Rust 1.54 fix since I needed it to make it work as well.