### PR TITLE
Always strip whitespace before parsing macOS version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -140,7 +140,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-instruments"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "anyhow",
  "cargo",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-instruments"
-version = "0.4.2"
+version = "0.4.3"
 authors = ["Colin Rofls <colin@cmyr.net>"]
 license = "MIT"
 description = "Profile binary targets on macOS using Xcode Instruments."

--- a/src/instruments.rs
+++ b/src/instruments.rs
@@ -148,7 +148,7 @@ fn semver_from_utf8(version: &[u8]) -> Result<Version> {
     match version_string.split('.').count() {
         1 => to_semver(&format!("{}.0.0", version_string.trim())),
         2 => to_semver(&format!("{}.0", version_string.trim())),
-        3 => to_semver(version_string),
+        3 => to_semver(version_string.trim()),
         _ => Err(anyhow!("invalid version: {}", version_string)),
     }
 }


### PR DESCRIPTION
Also bumps crate version.



fixes the first part of #50?