### PR TITLE
Upgrade cargo package from 0.55 to 0.57.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0"
-cargo = "0.55"
+cargo = "0.57"
 chrono = "0.4.6"
 structopt = { version = "^0.3", default-features = false }
 semver = "1.0"


### PR DESCRIPTION
Fix `failed to parse manifest at` when `edition = 2021` in `Cargo.toml`.