### PR TITLE
feat: support --package to specify the package to profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ As usual, thanks to Clap, running `cargo instruments -h` prints the compact help
             --bin <NAME>                   Binary to run
             --example <NAME>               Example binary to run
             --features <CARGO-FEATURES>    Features to pass to cargo
-            --package <NAME>               Specify package for example/bin/bench
+            --package <NAME>               Specify package to search for target (in a cargo workspace)
         -t, --template <TEMPLATE>          Specify the instruments template to run
             --time-limit <MILLIS>          Limit recording time to the specified value (in milliseconds)
         -o, --output <PATH>                Output .trace file to the given path

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ the bin `bar` of the package `foo`:
 $ cargo instruments --package foo --template alloc --bin bar
 ```
 
-In most of time, the package only has one binary which makes `--package` behaves the
+In many cases, a package only has one binary. In this case `--package` behaves the
 same as `--bin`.
 
 ### Profiling application in release mode

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ files that can be viewed in the Instruments app.
 ### Xcode Instruments
 
 This crate only works on macOS because it uses [Instruments] for profiling
-and creating the trace file.  The benefit is that Instruments provides great
+and creating the trace file. The benefit is that Instruments provides great
 templates and UI to explore the Profiling Trace.
 
 To install Xcode Instruments, simply install the Command Line Tools:
@@ -87,6 +87,19 @@ _Open the trace file in Instruments.app_ (or pass `--open` to open automatically
 $ open target/instruments/mybin_Allocations_2021-05-09T12:34:56.trace
 ```
 
+If there are mutliple packages, you can specify the package to profile with
+the `--package` flag.
+
+For example, you use Cargo's workspace to manage multiple packages. To profile
+the bin `bar` of the package `foo`:
+
+```sh
+$ cargo instruments --package foo --template alloc --bin bar
+```
+
+In most of time, the package only has one binary which makes `--package` behaves the
+same as `--bin`.
+
 ### Profiling application in release mode
 
 When profiling the application in release mode the compiler doesn't provide
@@ -124,6 +137,7 @@ As usual, thanks to Clap, running `cargo instruments -h` prints the compact help
             --bin <NAME>                   Binary to run
             --example <NAME>               Example binary to run
             --features <CARGO-FEATURES>    Features to pass to cargo
+            --package <NAME>               Specify package for example/bin/bench
         -t, --template <TEMPLATE>          Specify the instruments template to run
             --time-limit <MILLIS>          Limit recording time to the specified value (in milliseconds)
         -o, --output <PATH>                Output .trace file to the given path
@@ -162,7 +176,6 @@ Typically, the built-in templates are
     System Trace        (sys)
     Time Profiler       (time)
     Zombies
-
 
 ### Examples
 

--- a/src/opt.rs
+++ b/src/opt.rs
@@ -113,7 +113,7 @@ pub(crate) enum Target {
     Bench(String),
 }
 
-/// Represents the target of package for example, bin or bench
+/// The package in which to look for the specified target (example/bin/bench)
 #[derive(Debug, PartialEq)]
 pub(crate) enum Package {
     Default,

--- a/src/opt.rs
+++ b/src/opt.rs
@@ -114,7 +114,7 @@ pub(crate) enum Target {
 }
 
 /// The package in which to look for the specified target (example/bin/bench)
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub(crate) enum Package {
     Default,
     Package(String),
@@ -125,15 +125,6 @@ impl From<Package> for Packages {
         match p {
             Package::Default => Packages::Default,
             Package::Package(s) => Packages::Packages(vec![s]),
-        }
-    }
-}
-
-impl Clone for Package {
-    fn clone(&self) -> Self {
-        match self {
-            Package::Default => Package::Default,
-            Package::Package(s) => Package::Package(s.clone()),
         }
     }
 }


### PR DESCRIPTION
Solve #56  and #39  without breaking the architecture. 

When implementing this feature, I found  the method `fn validate_target` is redundant for validating the target. For Cargo builtin sub-commands, this is done by setting the field `spec` in `CompileOptions`. However, remove the method `validate_target` isn't enough.

The way `Cargo` used to construct a `ComplieOptions` is like following :
```rust
        let opts = CompileOptions {
            build_config,
            cli_features: self.cli_features()?,
            spec,
            filter: CompileFilter::from_raw_arguments(
                self.is_valid_and_present("lib"),
                self._values_of("bin"),
                self.is_valid_and_present("bins"),
                self._is_valid_arg("test")
                    .then(|| self._values_of("test"))
                    .unwrap_or_default(),
                self.is_valid_and_present("tests"),
                self._values_of("example"),
                self.is_valid_and_present("examples"),
                self._is_valid_arg("bench")
                    .then(|| self._values_of("bench"))
                    .unwrap_or_default(),
                self.is_valid_and_present("benches"),
                self.is_valid_and_present("all-targets"),
            ),
            target_rustdoc_args: None,
            target_rustc_args: None,
            target_rustc_crate_types: None,
            local_rustdoc_args: None,
            rustdoc_document_private_items: false,
            honor_rust_version: !self.is_valid_and_present("ignore-rust-version"),
        };
```  

In  implementation of `CompileOptions::new` , `spec: ops::Packages::Packages(Vec::new()),` makes the field `spec` an empty vector, which cause `Cargo` fail to find `bin`, `example`, `bench` for a virtual manifest. Unless we set the field `spec` explicitly to `Packages::Default` to tell `Cargo` to search the whole workspace.  For the sake of time, I didn't spend too much time digging in the internal logic.
  
```rust
    pub fn new(config: &Config, mode: CompileMode) -> CargoResult<CompileOptins> {
        let jobs = None;
        let keep_going = false;
        Ok(CompileOptions {
            build_config: BuildConfig::new(config, jobs, keep_going, &[], mode)?,
            cli_features: CliFeatures::new_all(false),
            spec: ops::Packages::Packages(Vec::new()),
            filter: CompileFilter::Default {
                required_features_filterable: false,
            },
            target_rustdoc_args: None,
            target_rustc_args: None,
            target_rustc_crate_types: None,
            local_rustdoc_args: None,
            rustdoc_document_private_items: false,
            honor_rust_version: true,
        })
    }

```

I implement the feature by introducing a `Enum` type `Package` that corresponds to Cargo's `Packages::Default` and `Packages::Packages(Vec<String>)` respectively. 

 I do not insist on this and will gladly to use other approach i.e. if there is a huge refactor on architecture.  Right now I'm using this patch for projects having more than one package.
