### PR TITLE
Instructions for building with a vendored OpenSSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,10 +45,18 @@ Alternatively, you can install from source.
 ### Building from Source
 
 First, ensure that you are running macOS, with Cargo, Xcode, and the Xcode
-Command Line Tools installed; then install with
+Command Line Tools installed.
+
+If OpenSSL is installed (e.g., via `brew`), then install with
 
 ```sh
 $ cargo install cargo-instruments
+```
+
+If OpenSSL is not installed or if `cargo install` fails with an error message starting with "Could not find directory of OpenSSL installation, and this `-sys` crate cannot proceed without this knowledge," then install with
+
+```sh
+$ cargo install --features vendored-openssl cargo-instruments
 ```
 
 #### Building from Source on nix
@@ -60,7 +68,7 @@ $ nix-shell --command 'cargo install cargo-instruments' --pure -p \
 	darwin.apple_sdk.frameworks.SystemConfiguration \
 	darwin.apple_sdk.frameworks.CoreServices \
 	rustc cargo sccache libgit2 pkg-config libiconv \
-	llvmPackages_13.libclang
+	llvmPackages_13.libclang openssl
 ```
 
 ## Usage


### PR DESCRIPTION
The `openssl-sys` crate expects to find the OpenSSL headers and libraries already installed. If they're not, then installing `cargo-instruments` fails. Installing with the `vendored-openssl` feature works in this case by causing `openssl-sys` to link a static copy of OpenSSL.

The Nix instructions were missing the `openssl` package so I added that too. I think the Nix instructions are wrong over all and should be removed in a subsequent commit. See my comment in #55 for why it's wrong.

Fixes: #72