### PR TITLE
--manifest-path option

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ debug = true
 As usual, thanks to Clap, running `cargo instruments -h` prints the compact help.
 
 ```
-cargo-instruments 0.4.5
+cargo-instruments 0.4.7
 Profile a binary with Xcode Instruments.
 
 By default, cargo-instruments will build your main binary.
@@ -150,6 +150,9 @@ OPTIONS:
         --bin <NAME>                   Binary to run
         --example <NAME>               Example binary to run
         --features <CARGO-FEATURES>    Features to pass to cargo
+        --manifest-path <PATH>         Path to Cargo.toml
+    -p, --package <NAME>               Specify package for example/bin/bench
+        --profile <NAME>               Pass --profile NAME to cargo
     -t, --template <TEMPLATE>          Specify the instruments template to run
         --time-limit <MILLIS>          Limit recording time to the specified value (in milliseconds)
     -o, --output <PATH>                Output .trace file to the given path
@@ -158,7 +161,7 @@ ARGS:
     <ARGS>...    Arguments passed to the target binary
 
 EXAMPLE:
-    cargo instruments -t time    Profile main binary with the (recommended) Time Profiler
+    cargo instruments -t time    Profile main binary with the (recommended) Time Profiler.
 ```
 
 And `cargo instruments --help` provides more detail.

--- a/src/app.rs
+++ b/src/app.rs
@@ -28,7 +28,10 @@ pub(crate) fn run(app_config: AppConfig) -> Result<()> {
 
     // 3. Build the specified target
     let cargo_config = Config::default()?;
-    let manifest_path = important_paths::find_root_manifest_for_wd(cargo_config.cwd())?;
+    let manifest_path = app_config
+        .manifest_path
+        .clone()
+        .map_or_else(|| important_paths::find_root_manifest_for_wd(cargo_config.cwd()), Ok)?;
     let workspace = Workspace::new(&manifest_path, &cargo_config)?;
 
     // 3.1: warn if --open passed. We do this here so we have access to cargo's

--- a/src/opt.rs
+++ b/src/opt.rs
@@ -92,6 +92,10 @@ pub(crate) struct AppConfig {
     #[structopt(long, value_name = "CARGO-FEATURES")]
     pub(crate) features: Option<String>,
 
+    /// Path to Cargo.toml
+    #[structopt(long, value_name = "PATH")]
+    pub(crate) manifest_path: Option<PathBuf>,
+
     /// Activate all features for the selected target.
     #[structopt(long, display_order = 1001)]
     pub(crate) all_features: bool,

--- a/src/opt.rs
+++ b/src/opt.rs
@@ -218,6 +218,7 @@ mod tests {
         assert!(!opts.release);
         assert!(opts.trace_filepath.is_none());
         assert!(opts.package.is_none());
+        assert!(opts.manifest_path.is_none());
     }
 
     #[test]
@@ -321,5 +322,21 @@ mod tests {
         assert_eq!(opts.template_name, Some("alloc".into()));
         assert_eq!(opts.time_limit, Some(808));
         assert_eq!(opts.target_args, vec!["hi", "-h", "--bin"]);
+    }
+
+    #[test]
+    fn manifest_path() {
+        let opts = AppConfig::from_iter(&[
+            "instruments",
+            "--manifest-path",
+            "/path/to/Cargo.toml",
+            "--template",
+            "alloc",
+        ]);
+        assert!(opts.example.is_none());
+        assert!(opts.bin.is_none());
+        assert!(opts.bench.is_none());
+        assert!(opts.package.is_none());
+        assert_eq!(opts.manifest_path.unwrap(), PathBuf::from("/path/to/Cargo.toml"));
     }
 }


### PR DESCRIPTION
Closes #76 

Adds support for a `--manifest-path` option to specify a path to `Cargo.toml`

I'm seeing expected behavior, per reading about Cargo subcommands I've been invoking the result of building this branch via `.../cargo-instruments/target/release/cargo-instruments instruments [...args]` and I'm seeing:

1. The target use case of invoking `cargo-instruments` from a different directory and pointing it at the target `Cargo.toml` via `--manifest-path` is working eg:
```
$ /Users/jrosse/prj/cargo-instruments/target/release/cargo-instruments instruments --release --manifest-path /Users/jrosse/prj/tsc-rust/typescript_rust/Cargo.toml -t time
[...runs cargo-instruments profiling...]
```

2. The "normal" use case of not specifying `--manifest-path` still works eg (from directory with `Cargo.toml`):
```
$ /Users/jrosse/prj/cargo-instruments/target/release/cargo-instruments instruments --release -t time -- tmp/variable-declaration.tsx
[...runs cargo-instruments profiling...]
```

3. When specifying a relative path for `--manifest-path` it fails in a seemingly reasonable way:
```
$ /Users/jrosse/prj/cargo-instruments/target/release/cargo-instruments instruments --release --manifest-path ../some/relative/path/Cargo.toml -t time
manifest_path:"../some/relative/path/Cargo.toml" is not an absolute path. Please provide an absolute path.
```

4. When specifying a nonexistent path for `--manifest-path` it fails in a seemingly reasonable way:
```
$ /Users/jrosse/prj/cargo-instruments/target/release/cargo-instruments instruments --release --manifest-path /Userz/jrosse/prj/tsc-rust/typescript_rust/Cargo.toml -t time
failed to read `/Userz/jrosse/prj/tsc-rust/typescript_rust/Cargo.toml`
```