### PR TITLE
Capture stdout from xctrace

### DIFF
--- a/src/instruments.rs
+++ b/src/instruments.rs
@@ -465,7 +465,9 @@ pub(crate) fn profile_target(
     if !output.status.success() {
         let stderr =
             String::from_utf8(output.stderr).unwrap_or_else(|_| "failed to capture stderr".into());
-        return Err(anyhow!("instruments errored: {}", stderr));
+        let stdout =
+            String::from_utf8(output.stdout).unwrap_or_else(|_| "failed to capture stdout".into());
+        return Err(anyhow!("instruments errored: {} {}", stderr, stdout));
     }
 
     Ok(trace_filepath)


### PR DESCRIPTION
When profiling an app I kept getting "**Failed** instruments errored: _blank_" (ie. no reason for the error).
Turns out xctrace was printing "Target app exited" (there was a problem with my command line) to std**OUT** and nothing to std**ERR**.

Looks like xctrace prints the interesting information to stdout instead of stderr in at least some scenarios, so including the output of both on failure.