### PR TITLE
feat: run benchmarks in non-bench targets

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -4,6 +4,7 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use anyhow::{anyhow, Result};
+use cargo::util::command_prelude::CompileMode;
 use cargo::{
     core::Workspace,
     ops::CompileOptions,
@@ -147,7 +148,9 @@ fn build_target(cargo_options: &CargoOpts, workspace: &Workspace) -> Result<Path
             .map(|unit_output| unit_output.path.clone())
             .ok_or_else(|| anyhow!("no benchmark '{}'", bench))
     } else {
-        match result.binaries.as_slice() {
+        let unit_outputs =
+            if cargo_options.mode == CompileMode::Bench { &result.tests } else { &result.binaries };
+        match unit_outputs.as_slice() {
             [unit_output] => Ok(unit_output.path.clone()),
             [] => Err(anyhow!("no targets found")),
             other => Err(anyhow!(
@@ -166,10 +169,9 @@ fn build_target(cargo_options: &CargoOpts, workspace: &Workspace) -> Result<Path
 /// This additionally filters options based on user args, so that Cargo
 /// builds as little as possible.
 fn make_compile_opts(cargo_options: &CargoOpts, cfg: &Config) -> Result<CompileOptions> {
-    use cargo::core::compiler::CompileMode;
     use cargo::ops::CompileFilter;
 
-    let mut compile_options = CompileOptions::new(cfg, CompileMode::Build)?;
+    let mut compile_options = CompileOptions::new(cfg, cargo_options.mode)?;
     let profile = &cargo_options.profile;
 
     compile_options.build_config.requested_profile = InternedString::new(profile);

--- a/src/instruments.rs
+++ b/src/instruments.rs
@@ -456,8 +456,10 @@ pub(crate) fn profile_target(
 
     command.arg(target_filepath);
 
-    if !app_config.target_args.is_empty() {
-        command.args(app_config.target_args.as_slice());
+    let bench_args = app_config.benchmarks.then_some("--bench".to_string());
+    let target_args = bench_args.iter().chain(&app_config.target_args).collect::<Vec<_>>();
+    if !target_args.is_empty() {
+        command.args(target_args.as_slice());
     }
 
     let output = command.output()?;


### PR DESCRIPTION
As discussed in and closes #84. I also made it use the `bench` profile by default when `--benchmarks` is supplied, and add the `--bench` argument to the target args like `cargo bench` does (otherwise it runs unit tests instead).

For reference, you can (optionally) [specify which benchmarks to run](https://doc.rust-lang.org/cargo/commands/cargo-bench.html) by adding them as target args:

```
cargo instruments -t time --benchmarks -- <my_bench_function_name>
```

Otherwise it'll run all of the benchmarks in the target.

Limitations:

- When there are multiple targets with benchmarks, I expect `cargo instruments -t time --benchmarks` to fail because it'll build multiple targets and it expects a single one (like if `--benchmarks` hadn't been supplied). AFAIK, `cargo instruments` can only run one target, so it has no analogous operation to `cargo bench` running benchmarks in multiple targets by default, so maybe this is OK. An alternative would be to run benchmarks in the main target by default, but this might be unexpected for users of `cargo bench`. Workaround is to specify a single target like `cargo instruments -t time --benchmarks --bin <crate_name>`. Might be nice to point users in this direction in the error message.
- I'm still unsure about the name of the flag being `--benchmarks` since everywhere else in `cargo` "bench" is used, but overloading the `--bench` option seems more confusing. I could see an argument for `--benchmark` as it looks like an action, instead of using two plurals in a row ("instruments", "benchmarks"). But `--benchmarks` makes it clear that it'll run all of them in the chosen target.
- If the user naively uses `cargo instruments --bench` without a value, the error message doesn't ask them to use `--benchmarks` instead. But I did add a note about it in the `--help` message for `--bench`.
- We're prepending `--bench` to the target args like `cargo bench` does, but I haven't checked the `cargo bench` source code to see if there are exceptions to this behavior (say, when the default test harness is disabled).
- Maybe `cargo instruments --bench` should imply `--benchmarks`? We'd probably want to use the `bench` profile by default, for example. I'm not using non-default test harnesses or separate bench targets though, so I haven't tested what the best behavior here should be.
- Cannot run benchmarks in lib or test targets.