### PR TITLE
feat: basic support for tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,8 @@ $ nix-shell --command 'cargo install cargo-instruments' --pure -p \
 
 `cargo-instruments` requires a binary target to run. By default, it will try to
 build the current crate's `main.rs`. You can specify an alternative binary by
-using the `--bin` or `--example` flags, or a benchmark target with the `--bench`
-flag.
+using the `--bin` or `--example` flags, a test target with the `--test` flag,
+or a benchmark target with the `--bench` flag.
 
 Assuming your crate has one binary target named `mybin`, and you want to profile
 using the `Allocations` Instruments template:
@@ -154,6 +154,7 @@ OPTIONS:
     -p, --package <NAME>               Specify package for example/bin/bench
         --profile <NAME>               Pass --profile NAME to cargo
     -t, --template <TEMPLATE>          Specify the instruments template to run
+        --test <NAME>                  Test target to run
         --time-limit <MILLIS>          Limit recording time to the specified value (in milliseconds)
     -o, --output <PATH>                Output .trace file to the given path
 
@@ -217,6 +218,15 @@ $ cargo instruments -t alloc
 # profile examples/my_example.rs, with the Allocations template,
 # for 10 seconds, and open the trace when finished
 $ cargo instruments -t Allocations --example my_example --time-limit 10000 --open
+```
+
+```shell
+# Profile a single test scanario with the File Activity template
+#
+# You will find `your_library_name` name by running `cargo test` and checking the 'Running' line.
+# e.g. Running unittests src/main.rs (target/debug/deps/your_library_name-3cabce0a041cfeed)
+# Optionally, you can provide a specific test case after the -- marker
+$ cargo instruments -t io --test your_library_name -- opt::tests::specific_test
 ```
 
 ## Resources

--- a/src/app.rs
+++ b/src/app.rs
@@ -150,10 +150,7 @@ fn build_target(cargo_options: &CargoOpts, workspace: &Workspace) -> Result<Path
         result
             .tests
             .iter()
-            .find(|unit_output| {
-                println!("testing output {}", unit_output.unit.target.name());
-                unit_output.unit.target.name() == test
-            })
+            .find(|unit_output| { unit_output.unit.target.name() == test })
             .map(|unit_output| unit_output.path.clone())
             .ok_or_else(|| anyhow!("no test '{}'", test))
     } else {

--- a/src/app.rs
+++ b/src/app.rs
@@ -59,10 +59,9 @@ pub(crate) fn run(mut app_config: AppConfig) -> Result<()> {
     #[cfg(target_arch = "aarch64")]
     codesign(&target_filepath, &workspace)?;
 
-
     if let Target::Test(_, ref tests) = cargo_options.target {
         app_config.target_args.insert(0, tests.clone());
-    } 
+    }
 
     // 4. Profile the built target, will display menu if no template was selected
     let trace_filepath =
@@ -139,7 +138,7 @@ fn codesign(path: &Path, workspace: &Workspace) -> Result<()> {
 /// the path to the built executable.
 fn build_target(cargo_options: &CargoOpts, workspace: &Workspace) -> Result<PathBuf> {
     use cargo::core::shell::Verbosity;
-    workspace.config().shell().set_verbosity(Verbosity::Verbose);
+    workspace.config().shell().set_verbosity(Verbosity::Normal);
 
     let compile_options = make_compile_opts(cargo_options, workspace.config())?;
     let result = cargo::ops::compile(workspace, &compile_options)?;
@@ -155,9 +154,7 @@ fn build_target(cargo_options: &CargoOpts, workspace: &Workspace) -> Result<Path
         result
             .tests
             .iter()
-            .find(|unit_output| {
-                unit_output.unit.target.name() == harness
-            })
+            .find(|unit_output| unit_output.unit.target.name() == harness)
             .map(|unit_output| unit_output.path.clone())
             .ok_or_else(|| anyhow!("no test '{}'", harness))
     } else {

--- a/src/app.rs
+++ b/src/app.rs
@@ -150,7 +150,7 @@ fn build_target(cargo_options: &CargoOpts, workspace: &Workspace) -> Result<Path
         result
             .tests
             .iter()
-            .find(|unit_output| { unit_output.unit.target.name() == test })
+            .find(|unit_output| unit_output.unit.target.name() == test)
             .map(|unit_output| unit_output.path.clone())
             .ok_or_else(|| anyhow!("no test '{}'", test))
     } else {

--- a/src/opt.rs
+++ b/src/opt.rs
@@ -56,6 +56,14 @@ pub(crate) struct AppConfig {
     #[structopt(long, group = "target", value_name = "NAME")]
     bench: Option<String>,
 
+    /// Test harness target to run
+    #[structopt(long, group = "target", value_name = "NAME")]
+    harness: Option<String>,
+
+    /// Test target to run
+    #[structopt(long, value_name = "NAME")]
+    test: Option<String>,
+
     /// Pass --release to cargo
     #[structopt(long, conflicts_with = "profile")]
     release: bool,
@@ -119,6 +127,7 @@ pub(crate) enum Target {
     Example(String),
     Bin(String),
     Bench(String),
+    Test(String, String),
 }
 
 /// The package in which to look for the specified target (example/bin/bench)
@@ -155,6 +164,7 @@ impl fmt::Display for Target {
             Target::Example(bin) => write!(f, "examples/{}.rs", bin),
             Target::Bin(bin) => write!(f, "bin/{}.rs", bin),
             Target::Bench(bench) => write!(f, "bench {}", bench),
+            Target::Test(harness, test) => write!(f, "test {} {}", harness, test),
         }
     }
 }
@@ -192,7 +202,7 @@ impl AppConfig {
         }
     }
 
-    // valid target: --example,  --bin, --bench
+    // valid target: --example,  --bin, --bench, --harness
     fn get_target(&self) -> Target {
         if let Some(ref example) = self.example {
             Target::Example(example.clone())
@@ -200,6 +210,10 @@ impl AppConfig {
             Target::Bin(bin.clone())
         } else if let Some(ref bench) = self.bench {
             Target::Bench(bench.clone())
+        } else if let Some(ref harness) = self.harness {
+            let test = self.test.clone().unwrap_or_default();
+            Target::Test(harness.clone(), test)
+
         } else {
             Target::Main
         }

--- a/src/opt.rs
+++ b/src/opt.rs
@@ -213,7 +213,6 @@ impl AppConfig {
         } else if let Some(ref harness) = self.harness {
             let test = self.test.clone().unwrap_or_default();
             Target::Test(harness.clone(), test)
-
         } else {
             Target::Main
         }

--- a/src/opt.rs
+++ b/src/opt.rs
@@ -56,12 +56,8 @@ pub(crate) struct AppConfig {
     #[structopt(long, group = "target", value_name = "NAME")]
     bench: Option<String>,
 
-    /// Test harness target to run
-    #[structopt(long, group = "target", value_name = "NAME")]
-    harness: Option<String>,
-
     /// Test target to run
-    #[structopt(long, value_name = "NAME")]
+    #[structopt(long, group = "target", value_name = "NAME")]
     test: Option<String>,
 
     /// Pass --release to cargo
@@ -127,7 +123,7 @@ pub(crate) enum Target {
     Example(String),
     Bin(String),
     Bench(String),
-    Test(String, String),
+    Test(String),
 }
 
 /// The package in which to look for the specified target (example/bin/bench)
@@ -164,7 +160,7 @@ impl fmt::Display for Target {
             Target::Example(bin) => write!(f, "examples/{}.rs", bin),
             Target::Bin(bin) => write!(f, "bin/{}.rs", bin),
             Target::Bench(bench) => write!(f, "bench {}", bench),
-            Target::Test(harness, test) => write!(f, "test {} {}", harness, test),
+            Target::Test(test) => write!(f, "test {}", test),
         }
     }
 }
@@ -210,9 +206,8 @@ impl AppConfig {
             Target::Bin(bin.clone())
         } else if let Some(ref bench) = self.bench {
             Target::Bench(bench.clone())
-        } else if let Some(ref harness) = self.harness {
-            let test = self.test.clone().unwrap_or_default();
-            Target::Test(harness.clone(), test)
+        } else if let Some(ref test) = self.test {
+            Target::Test(test.clone())
         } else {
             Target::Main
         }


### PR DESCRIPTION
This implements https://github.com/cmyr/cargo-instruments/issues/93

Tests are essentially a binary file in `target/debug/deps/library_name` folder. That binary accepts test names as arguments. This PR uses `--harness` option as the library_name (required), and an optional `--test` option to pass arguments to the test harness binary.