### PR TITLE
Implement hacky demangling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -384,6 +384,8 @@ dependencies = [
  "clap",
  "env_logger",
  "log",
+ "object",
+ "rustc-demangle",
  "semver",
 ]
 
@@ -2740,6 +2742,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3165,6 +3176,12 @@ dependencies = [
  "smallvec",
  "sqlite-wasm-rs",
 ]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
 
 [[package]]
 name = "rustc-hash"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,5 @@ clap = { version = "4", features = ["derive"] }
 semver = "1.0"
 env_logger = "0.11.0"
 log = "0.4.20"
+object = { version = "0.37", default-features = false, features = ["read_core", "macho"] }
+rustc-demangle = "0.1"

--- a/src/app.rs
+++ b/src/app.rs
@@ -11,6 +11,7 @@ use cargo::{
     util::{important_paths, interning::InternedString},
 };
 
+use crate::demangle;
 use crate::instruments;
 use crate::opt::{AppConfig, CargoOpts, Target};
 
@@ -28,7 +29,20 @@ pub(crate) fn run(app_config: AppConfig) -> Result<()> {
     }
 
     // 3. Build the specified target
-    let cargo_config = GlobalContext::default()?;
+    let cargo_options = app_config.to_cargo_opts()?;
+
+    let mut cargo_config = GlobalContext::default()?;
+    cargo_config.configure(
+        0,
+        false,
+        None,
+        false,
+        false,
+        false,
+        &None,
+        &[],
+        &[format!("profile.{}.split-debuginfo='packed'", cargo_options.profile)],
+    )?;
 
     let manifest_path = match app_config.manifest_path.as_ref() {
         Some(path) if path.is_absolute() => Ok(path.to_owned()),
@@ -49,8 +63,6 @@ pub(crate) fn run(app_config: AppConfig) -> Result<()> {
             .warn("--open is now the default behaviour, and will be ignored.")?;
     }
 
-    let cargo_options = app_config.to_cargo_opts()?;
-
     log::debug!("building profile target {}", cargo_options.target);
     let target_filepath = match build_target(&cargo_options, &workspace) {
         Ok(path) => path,
@@ -60,11 +72,23 @@ pub(crate) fn run(app_config: AppConfig) -> Result<()> {
         }
     };
 
-    log::debug!("running against target {}", target_filepath.display());
+    if !app_config.no_demangle {
+        if let Err(e) = demangle::demangle_binary(&target_filepath) {
+            workspace.gctx().shell().warn(format!(
+                "failed to demangle symbols: {e:#}\n\
+                 Note: symbol demangling is experimental. If you see this message, \
+                 please open an issue at https://github.com/cmyr/cargo-instruments/issues \
+                 including your macOS and Xcode versions."
+            ))?;
+        }
+    } else {
+        demangle::just_invalidate_symbol_cache(&target_filepath);
+    }
 
     #[cfg(target_arch = "aarch64")]
     codesign(&target_filepath, &workspace)?;
 
+    log::debug!("running against target {}", target_filepath.display());
     // 4. Profile the built target, will display menu if no template was selected
     let trace_filepath =
         match instruments::profile_target(&target_filepath, &xctrace_tool, &app_config, &workspace)

--- a/src/demangle.rs
+++ b/src/demangle.rs
@@ -1,0 +1,252 @@
+//! Demangle Rust symbols in a Mach-O binary's symbol table, in place.
+
+use std::ops::Range;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Result, anyhow};
+use object::Endianness;
+use object::macho;
+use object::read::macho::{LoadCommandVariant, MachHeader, Segment};
+
+/// Metadata extracted from a Mach-O binary's load commands.
+struct MachoInfo {
+    /// Byte ranges containing null-terminated symbol name strings that we can
+    /// patch in place. Typically the `LC_SYMTAB` string table and the
+    /// `__debug_str` DWARF section.
+    string_regions: Vec<Range<usize>>,
+    /// The binary's UUID from `LC_UUID`, used to invalidate the
+    /// `coresymbolicationd` symbol cache after patching.
+    uuid: Option<String>,
+}
+
+/// Demangle Rust symbol names in the binary and its dSYM bundle (if present).
+///
+/// This is a hack, but it makes it much easier to read the names of functions
+/// in Instruments, so instead of:
+///
+/// ```no_format
+/// _$LT$alloc..vec..Vec$LT$T$C$A$GT$$u20$as$u20$alloc..vec..spec_extend..SpecExtend$LT$T$C$I$GT$$GT$::spec_extend::hb9d6b49df4cfa5e3
+/// ```
+/// we get,
+///
+/// ```no_format
+/// <alloc::vec::Vec<T, A> as alloc::vec::spec_extend::SpecExtend<T, I>>::spec_extend
+/// ```
+pub fn demangle_binary(path: &Path) -> Result<()> {
+    let uuid = demangle_macho(path)?;
+
+    // Invalidate the coresymbolicationd symbol cache for this binary, just in
+    // case a previous profiling session cached the old (mangled) names.
+    // Best-effort: symbolscache may not exist or the daemon may not be running.
+    if let Some(uuid) = uuid {
+        invalidate_symbol_cache(&uuid);
+    }
+
+    if let Some(dsym_path) = find_dsym_dwarf(path) {
+        demangle_macho(&dsym_path)?;
+    }
+
+    Ok(())
+}
+
+/// Find the DWARF binary inside a dSYM bundle adjacent to `path`.
+///
+/// Given `target/debug/foo`, looks for
+/// `target/debug/foo.dSYM/Contents/Resources/DWARF/*` and returns
+/// the first Mach-O file found (the DWARF file name may include a hash).
+fn find_dsym_dwarf(binary_path: &Path) -> Option<PathBuf> {
+    let file_name = binary_path.file_name()?;
+    let dsym_dir = binary_path.parent()?.join(format!("{}.dSYM", file_name.to_str()?));
+    let dwarf_dir = dsym_dir.join("Contents/Resources/DWARF");
+    let entry = std::fs::read_dir(&dwarf_dir).ok()?.next()?.ok()?;
+    Some(entry.path())
+}
+
+/// Demangle Rust symbol names in a Mach-O file's string tables, in place.
+///
+/// Patches both the `LC_SYMTAB` string table and the `__debug_str` DWARF
+/// section (which is what `atos`/Instruments actually reads).
+/// Returns the binary's UUID if found.
+fn demangle_macho(path: &Path) -> Result<Option<String>> {
+    let mut data = std::fs::read(path)?;
+    let info = parse_macho(&data)?;
+
+    if info.string_regions.is_empty() {
+        log::debug!("no string tables found in {}, skipping", path.display());
+        return Ok(info.uuid);
+    }
+
+    let mut total = 0usize;
+    for region in &info.string_regions {
+        total += demangle_region(&mut data, region.clone());
+    }
+
+    if total > 0 {
+        std::fs::write(path, &data)?;
+        log::debug!("demangled {total} symbols in {}", path.display());
+    }
+
+    Ok(info.uuid)
+}
+
+/// Walk a region of \0 terminated strings, demangling in place.
+///
+/// Returns the number of names replaced.
+fn demangle_region(data: &mut [u8], region: Range<usize>) -> usize {
+    let end = region.end;
+    let mut pos = region.start;
+    let mut count = 0;
+
+    while pos < end {
+        let nul = data[pos..end].iter().position(|&b| b == 0).map(|i| pos + i).unwrap_or(end);
+
+        let name = std::str::from_utf8(&data[pos..nul]);
+        let available = nul - pos;
+        if let Ok(name) = name {
+            let demangled = format!("{:#}", rustc_demangle::demangle(name));
+            if demangled != name && demangled.len() <= available {
+                data[pos..pos + demangled.len()].copy_from_slice(demangled.as_bytes());
+                data[pos + demangled.len()] = 0;
+                count += 1;
+            }
+        }
+
+        pos = nul + 1;
+    }
+
+    count
+}
+
+/// Extract the string regions and UUID from a Mach-O binary's load commands.
+fn parse_macho(data: &[u8]) -> Result<MachoInfo> {
+    let header = macho::MachHeader64::<Endianness>::parse(data, 0)
+        .map_err(|e| anyhow!("failed to parse Mach-O header: {e}"))?;
+    let endian = header.endian().map_err(|e| anyhow!("bad endianness: {e}"))?;
+
+    let mut string_regions = Vec::new();
+    let mut uuid = None;
+
+    let mut commands = header
+        .load_commands(endian, data, 0)
+        .map_err(|e| anyhow!("failed to read load commands: {e}"))?;
+
+    while let Some(command) =
+        commands.next().map_err(|e| anyhow!("failed to iterate load commands: {e}"))?
+    {
+        let variant =
+            command.variant().map_err(|e| anyhow!("failed to parse load command: {e}"))?;
+
+        match variant {
+            LoadCommandVariant::Symtab(symtab) => {
+                let off = symtab.stroff.get(endian) as usize;
+                let size = symtab.strsize.get(endian) as usize;
+                if off + size <= data.len() {
+                    string_regions.push(off..off + size);
+                }
+            }
+            LoadCommandVariant::Segment64(segment, section_data) => {
+                if let Ok(sections) = segment.sections(endian, section_data) {
+                    for section in sections {
+                        if section.sectname.starts_with(b"__debug_str\0") {
+                            let off = section.offset.get(endian) as usize;
+                            let size = section.size.get(endian) as usize;
+                            if off + size <= data.len() {
+                                string_regions.push(off..off + size);
+                            }
+                        }
+                    }
+                }
+            }
+            LoadCommandVariant::Uuid(cmd) => {
+                uuid = Some(format_uuid(&cmd.uuid));
+            }
+            _ => {}
+        }
+    }
+
+    Ok(MachoInfo { string_regions, uuid })
+}
+
+/// Invalidate the symbol cache for a binary without demangling it.
+///
+/// Used when `--no-demangle` is passed: we still want to clear any stale
+/// cached symbols from a previous profiling session.
+pub fn just_invalidate_symbol_cache(path: &Path) {
+    let uuid = std::fs::read(path).ok().and_then(|data| parse_uuid(&data));
+
+    if let Some(uuid) = uuid {
+        invalidate_symbol_cache(&uuid);
+    }
+}
+
+/// Extract just the UUID from a Mach-O binary's load commands.
+fn parse_uuid(data: &[u8]) -> Option<String> {
+    let header = macho::MachHeader64::<Endianness>::parse(data, 0).ok()?;
+    let endian = header.endian().ok()?;
+    let mut commands = header.load_commands(endian, data, 0).ok()?;
+
+    while let Some(command) = commands.next().ok()? {
+        if let Ok(LoadCommandVariant::Uuid(cmd)) = command.variant() {
+            return Some(format_uuid(&cmd.uuid));
+        }
+    }
+
+    None
+}
+
+fn format_uuid(bytes: &[u8; 16]) -> String {
+    bytes.iter().map(|b| format!("{b:02X}")).collect()
+}
+
+/// Invalidate the `coresymbolicationd` symbol cache for a given UUID.
+///
+/// macOS caches symbolication data per-binary (keyed by UUID) via the
+/// `coresymbolicationd` daemon. If the user previously profiled this binary,
+/// the cache may contain the old mangled names. This is best-effort: we
+/// silently ignore failures since `symbolscache` may not be available.
+fn invalidate_symbol_cache(uuid: &str) {
+    match std::process::Command::new("symbolscache").args(["delete", uuid]).output() {
+        Ok(output) if output.status.success() => {
+            log::debug!("invalidated symbol cache for {uuid}");
+        }
+        _ => {
+            log::debug!("symbolscache delete for {uuid} failed or not available (this is ok)");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::process::Command;
+
+    #[test]
+    fn demangle_test_binary() {
+        // Work on a copy of our own test binary
+        let self_exe = std::env::current_exe().unwrap();
+        let dir = std::env::temp_dir().join("cargo_instruments_test");
+        std::fs::create_dir_all(&dir).unwrap();
+        let bin = dir.join("test_bin");
+        std::fs::copy(&self_exe, &bin).unwrap();
+
+        // verify mangled symbols exist and demangled ones don't
+        let before = Command::new("nm").arg("--no-demangle").arg(&bin).output().unwrap();
+        let before = String::from_utf8_lossy(&before.stdout);
+        assert!(before.contains("_ZN"), "expected mangled symbols in binary");
+        assert!(
+            !before.contains("demangle::demangle_region"),
+            "demangled symbol should not be present before patching"
+        );
+
+        // run demangling
+        demangle_binary(&bin).unwrap();
+
+        // verify our own symbols are demangled in the binary itself
+        let after = Command::new("nm").arg("--no-demangle").arg(&bin).output().unwrap();
+        let after = String::from_utf8_lossy(&after.stdout);
+        assert!(
+            after.contains("demangle::demangle_region"),
+            "expected demangled symbol 'demangle::demangle_region', got:\n{after}"
+        );
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 mod app;
+mod demangle;
 mod instruments;
 mod opt;
 

--- a/src/opt.rs
+++ b/src/opt.rs
@@ -104,6 +104,10 @@ pub(crate) struct AppConfig {
     #[arg(long, display_order = 1001)]
     pub(crate) no_default_features: bool,
 
+    /// Do not demangle Rust symbols in the profiling output.
+    #[structopt(long, display_order = 1001)]
+    pub(crate) no_demangle: bool,
+
     /// Arguments passed to the target binary.
     ///
     /// To pass flags, precede child args with `--`,


### PR DESCRIPTION
Something that has bothered me for a long time is that the library Instruments uses for demangling symbols does not handle Rust very well.

After a long back-and-forth with claude, this patch adds code to perform more manual demangling; the basic gist is that (at least for Sequoia, at least for this version of Xcode) We can now provide much more useful symbol names.

Fun fact: did you know that there's a daemon coresymbolicationd, which maintains a cache of symbol names for binaries? Nor did I, but I sure do now.

In any case, this should replace things that look like,

_$LT$alloc..vec..Vec$LT$T$C$A$GT$$u20$as$u20$alloc..vec..spec_extend..SpecExtend$LT$T$C$I$GT$$GT$::spec_extend::hb9d6b49df4cfa5e3

With the much nicer,
<alloc::vec::Vec<T, A> as alloc::vec::spec_extend::SpecExtend<T, I>>::spec_extend

In case this is broken for anyone, you can pass --no-demangle to opt-out.

Key details:
  - Patches both the main binary and its dSYM bundle in place, replacing mangled names with demangled versions when the demangled form fits in the available space
  - Forces `split-debuginfo=packed` so cargo produces a dSYM bundle
  - Invalidates the macOS `coresymbolicationd` symbol cache (keyed by binary UUID) after patching, since stale cached entries from prior profiling sessions would mask the patched names
  - Demangling is best-effort: failures produce a warning but do not block profiling, since this relies on Mach-O layout conventions that may vary across macOS/Xcode versions